### PR TITLE
Move side-effect inside useEffect hook

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -46,7 +46,6 @@ export function useValue<T extends StateObject, U>(
 
     if (!subscriberRef.current) {
         subscriberRef.current = new Subscriber(state, forceUpdate, selector)
-        subscriberRef.current.subscribe()
     }
 
     const subscriber = subscriberRef.current
@@ -66,7 +65,10 @@ export function useValue<T extends StateObject, U>(
         subscriber.errored = false
     })
 
-    useIsoLayoutEffect(() => subscriber.unsubscribe, [])
+    useIsoLayoutEffect(() => {
+        subscriber.subscribe()
+        return subscriber.unsubscribe
+    }, [subscriber])
 
     return hasNewValue ? newValue : subscriber.currentValue
 }


### PR DESCRIPTION
This fixes a weird behaviour we saw when using React.StrictMode, where useEffect is not re-triggered when depending on a value from useValue.

The problem was that we called subscribe directly in useValue without wrapping it in a useEffect. All side-effects should be wrapped in useEffect hooks. Still not sure exactly how an extra subscription could cause this issue, though.

For more info see: https://github.com/facebook/react/issues/20714